### PR TITLE
fix: enable syntax highlighting when viewing on github

### DIFF
--- a/doc/dap.txt
+++ b/doc/dap.txt
@@ -830,3 +830,5 @@ pick_process()                                         *dap.utils.pick_process*
 
         This uses `ps a` to retrieve the process list and won't work if `ps a`
         is not available
+
+vim:ft=help


### PR DESCRIPTION
Seems like this is what GitHub looks for to set some highlights on the web viewer.
https://github.com/neovim/neovim/blob/9337fff8aad610acd5ef619f757686c47f0c118c/runtime/doc/api.txt#L2857